### PR TITLE
Se agrega opcion para cambiar el dia en que se resetea cada chat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .env
 data.json
+data_v2.json


### PR DESCRIPTION
**Disclaimer:** No trabajo con javascript, debe ser la 4ta vez que lo toco 😛

**TL;DR:** Para cambiar el dia en que se resetea un chat agregue el comando `/reset_on {lunes|martes|...}` que cambia el dia en que se resetea el chat actual.

Oliver resetea los partidos todos los lunes. Esto es porque los lunes son considerados el comienzo de la semana y los partidos se guardan por cada semana.

Para poder controlar que dia se resetean los partidos tuve que parametrizar que dia comienza la semana para cada chat.
Para esto tuve que guardar cual es el comienzo de la semana para cada chat id (el default es el lunes). Como cada chat puede resetearse en un dia distinto, el numero de semana ya no es el mismo para todos los chats. 

Por esto tuve que cambiar el formato de la persistencia en disco. Cambie el nombre del archivo donde lo persiste para no pisar el actual, por las dudas.

Para debuggear agregue un comando  `/debug_bttf {#dias}` donde se le indica la cantidad de dias que se quiere modificar la fecha de Oliver, para probar el cambio de dias y como se resetean los partidos el dia indicado. Por ejemplo `/debug_bttf 1` adelanta un dia y `/debug_bttf -2` la atrasa dos dias. `bttf` stands for _Back To The Future_ 😛.

